### PR TITLE
add support for .osu maps from osu!

### DIFF
--- a/src/bms/model/ChartDecoder.java
+++ b/src/bms/model/ChartDecoder.java
@@ -63,6 +63,8 @@ public abstract class ChartDecoder {
 			return new BMSDecoder(BMSModel.LNTYPE_LONGNOTE);
 		} else if (s.endsWith(".bmson")) {
 			return new BMSONDecoder(BMSModel.LNTYPE_LONGNOTE);
+		} else if (s.endsWith(".osu")) {
+			return new OSUDecoder(BMSModel.LNTYPE_LONGNOTE);
 		}
 		return null;
 	}

--- a/src/bms/model/OSUDecoder.java
+++ b/src/bms/model/OSUDecoder.java
@@ -138,19 +138,31 @@ public class OSUDecoder extends ChartDecoder {
 			if (point.uninherited) {
 				timingPoints.add(point);
 
-				if (i != osu.timingPoints.size() - 1 && !osu.timingPoints.get(i+1).time.equals(point.time)) {
-					TimingPoints sv = new TimingPoints();
-					sv.time = point.time;
-					sv.beatLength = -100.f;
-					sv.meter = point.meter;
-					sv.sampleSet = point.sampleSet;
-					sv.sampleIndex = point.sampleIndex;
-					sv.volume = point.volume;
-					sv.uninherited = false;
-					sv.effects = point.effects;
+				TimingPoints sv = new TimingPoints();
+				sv.time = point.time;
+				sv.beatLength = -100.f;
+				sv.meter = point.meter;
+				sv.sampleSet = point.sampleSet;
+				sv.sampleIndex = point.sampleIndex;
+				sv.volume = point.volume;
+				sv.uninherited = false;
+				sv.effects = point.effects;
+				if (i != osu.timingPoints.size() - 1) {
+					if (!osu.timingPoints.get(i+1).time.equals(point.time)) {
+						svs.add(sv);
+					}
+				}
+				else {
 					svs.add(sv);
 				}
 			} else {
+				if (!svs.isEmpty()) {
+					TimingPoints lastSv = svs.get(svs.size() - 1);
+					if (lastSv.time.equals(point.time)) {
+						lastSv.beatLength = point.beatLength;
+						continue;
+					}
+				}
 				svs.add(point);
 			}
 		}
@@ -163,6 +175,7 @@ public class OSUDecoder extends ChartDecoder {
 		bgmTl.setBPM(GetBpm(timingPoints, bgmTl.getTime()));
 		bgmTl.setScroll(GetSv(svs, bgmTl.getTime()));
 		bgmTl.setBGA(0);
+		bgmTl.setSectionLine(true);
 
 		for (TimingPoints point : timingPoints) {
 			TimeLine timeline = GetTimeline(timelines, point.time.intValue(), GetSection(timingPoints, point.time.intValue()));

--- a/src/bms/model/OSUDecoder.java
+++ b/src/bms/model/OSUDecoder.java
@@ -1,0 +1,210 @@
+package bms.model;
+
+import bms.model.osu.*;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class OSUDecoder extends ChartDecoder {
+
+	private BMSModel model;
+
+	public OSUDecoder(int lntype) { this.lntype = lntype; }
+
+	public BMSModel decode(ChartInformation info) {
+		this.lntype = info.lntype;
+		return decode(info.path);
+	}
+
+	public BMSModel decode(Path f) {
+		MessageDigest md5digest, sha256digest;
+		try {
+			md5digest = MessageDigest.getInstance("MD5");
+			sha256digest = MessageDigest.getInstance("SHA-256");
+		} catch (NoSuchAlgorithmException e1) {
+			e1.printStackTrace();
+			return null;
+		}
+		BufferedReader br;
+		try {
+			br = new BufferedReader(new InputStreamReader(
+					new DigestInputStream(new DigestInputStream(new ByteArrayInputStream(Files.readAllBytes(f)), md5digest), sha256digest),
+					"MS932"));
+
+		} catch (IOException e) {
+			e.printStackTrace();
+			return null;
+		}
+		Osu osu = new Osu(br);
+		model = new BMSModel();
+		model.setMD5(BMSDecoder.convertHexString(md5digest.digest()));
+		model.setSHA256(BMSDecoder.convertHexString(sha256digest.digest()));
+		if (osu.general.mode != 3) return null;
+
+		int keymode = osu.difficulty.circleSize.intValue();
+		model.setTitle(osu.metadata.title);
+		model.setSubTitle("[" + osu.metadata.version + "]");
+		model.setArtist(osu.metadata.artist);
+		model.setSubArtist(osu.metadata.creator);
+		model.setGenre(keymode + "K");
+		model.setJudgerank(3);
+		model.setJudgerankType(BMSModel.JudgeRankType.BMS_RANK);
+		model.setTotal(0);
+		model.setTotalType(BMSModel.TotalType.BMS);
+		model.setPlaylevel("");
+		int[] mapping;
+		switch (keymode) {
+			case 4: {
+				model.setMode(Mode.BEAT_7K);
+				mapping = new int[]{0, 2, 4, 6, -1, -1, -1, -1};
+				break;
+			}
+			case 5: {
+				model.setMode(Mode.BEAT_5K);
+				mapping = new int[]{0, 1, 2, 3, 4, -1};
+				break;
+			}
+			case 6: {
+				model.setMode(Mode.BEAT_7K);
+				mapping = new int[]{0, 1, 2, 4, 5, 6, -1};
+				break;
+			}
+			case 7: {
+				model.setMode(Mode.BEAT_7K);
+				mapping = new int[]{0, 1, 2, 3, 4, 5, 6, -1};
+				break;
+			}
+			case 8: {
+				model.setMode(Mode.BEAT_7K);
+				mapping = new int[]{7, 0, 1, 2, 3, 4, 5, 6};
+				break;
+			}
+			case 9: {
+				model.setMode(Mode.POPN_9K);
+				mapping = new int[]{0, 1, 2, 3, 4, 5, 6, 7, 8};
+				break;
+			}
+			case 10: {
+				model.setMode(Mode.BEAT_10K);
+				mapping = new int[]{0, 1, 2, 3, 4, 6, 7, 8, 9, 10, -1, -1};
+				break;
+			}
+			case 12: {
+				model.setMode(Mode.BEAT_10K);
+				mapping = new int[]{5, 0, 1, 2, 3, 4, 6, 7, 8, 9, 10, 11};
+				break;
+			}
+			case 14: {
+				model.setMode(Mode.BEAT_14K);
+				mapping = new int[]{0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14, -1};
+				break;
+			}
+			case 16: {
+				model.setMode(Mode.BEAT_14K);
+				mapping = new int[]{7, 0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 11, 12, 13, 14};
+				break;
+			}
+			default:
+				return null;
+		}
+		model.setLnmode(BMSModel.LNTYPE_LONGNOTE);
+		model.setBanner("");
+		for (int i = 0; i < osu.events.size(); i++) {
+			try {
+				Events event = osu.events.get(i);
+				if (Integer.parseInt(event.eventType) != 0) continue;
+				model.setBackbmp(event.eventParams.get(0));
+				model.setStagefile(event.eventParams.get(0));
+			} catch (NumberFormatException e) {
+				continue;
+			}
+		}
+		model.setPreview("");
+
+		TreeMap<Integer, TimeLine> timelines = new TreeMap<Integer, TimeLine>();
+		TreeMap<Integer, Float> svs = new TreeMap<Integer, Float>();
+		TreeMap<Integer, TimingPoints> timingPoints = new TreeMap<Integer, TimingPoints>();
+		for (int i = 0; i < osu.timingPoints.size(); i++) {
+			TimingPoints point = osu.timingPoints.get(i);
+			if (point.uninherited) {
+				timingPoints.put(point.time.intValue(), point);
+			} else {
+				float sv = point.beatLength;
+				sv = 100.f / (-sv);
+				svs.put(point.time.intValue(), sv);
+			}
+		}
+		model.setBpm(1 / timingPoints.firstEntry().getValue().beatLength * 1000 * 60);
+		Vector<String> wavmap = new Vector<String>();
+		wavmap.add(osu.general.audioFilename);
+		wavmap.add("");
+		TimeLine bgmTl = new TimeLine(0, 0, model.getMode().key);
+		Note bgm = new NormalNote(0, 0, 0);
+		bgmTl.addBackGroundNote(bgm);
+		bgmTl.setBPM(model.getBpm());
+		bgmTl.setBGA(0);
+		timelines.put(0, bgmTl);
+
+		TimingPoints timingPoint = timingPoints.firstEntry().getValue();
+		//TimingPoints nextTimingPoint = timingPoints.higherEntry(timingPoint.time.intValue()) != null ?
+		//		timingPoints.higherEntry(timingPoint.time.intValue()).getValue() : null;
+		//float sv = svs.firstEntry() != null ? svs.firstEntry().getValue() : 1.f;
+		for (int i = 0; i < osu.hitObjects.size(); i++) {
+			HitObjects hitObject = osu.hitObjects.get(i);
+
+			int columnIdx = ((int) Math.floor(hitObject.x * keymode / 512.f));
+			columnIdx = Math.max(0, Math.min(keymode - 1, columnIdx));
+			double section = hitObject.time / (timingPoint.beatLength * timingPoint.meter);
+
+			TimeLine timeline = timelines.get(hitObject.time);
+			if (timeline == null) {
+				timeline = new TimeLine(section, hitObject.time.longValue() * 1000, model.getMode().key);
+				timelines.put(hitObject.time, timeline);
+			}
+			timeline.setBPM(model.getBpm());
+			Boolean isManiaHold = (hitObject.type & 0x80) > 0;
+			int wavIdx = 1;
+		/*if (!hitObject.hitSample.filename.isEmpty()) { // keysounds potentially go here.
+			wavIdx = wavmap.size();
+			wavmap.add(hitObject.hitSample.filename);
+		}*/
+			if (isManiaHold) {
+				LongNote head = new LongNote(wavIdx, hitObject.time * 1000, 0);
+				timeline.setNote(mapping[columnIdx], head);
+
+				int tailTimeMs = Integer.parseInt(hitObject.objectParams.get(0));
+				long tailTimeUs = (long) tailTimeMs * 1000;
+				double tailSection = (double) tailTimeMs / (timingPoint.beatLength * timingPoint.meter);
+				LongNote tail = new LongNote(wavIdx, tailTimeUs, 0);
+
+				TimeLine tailTl = timelines.get(tailTimeMs);
+				if (tailTl == null) {
+					tailTl = new TimeLine(tailSection, tailTimeUs, model.getMode().key);
+					timelines.put(tailTimeMs, timeline);
+				}
+				tailTl.setBPM(model.getBpm());
+				tailTl.setNote(mapping[columnIdx], tail);
+				timelines.put(Integer.parseInt(hitObject.objectParams.get(0)), tailTl);
+
+				head.setPair(tail);
+				tail.setPair(head);
+			} else {
+				NormalNote note = new NormalNote(wavIdx, hitObject.time * 1000, 0);
+				timeline.setNote(mapping[columnIdx], note);
+			}
+		}
+		model.setWavList(wavmap.toArray(new String[wavmap.size()]));
+		model.setAllTimeLine(timelines.values().stream().collect(Collectors.toList()).toArray(new TimeLine[timelines.size()]));
+		String[] bgaList = {model.getBackbmp()};
+		model.setBgaList(bgaList);
+		model.setChartInformation(new ChartInformation(f, lntype, null));
+		return model;
+	}
+}

--- a/src/bms/model/OSUDecoder.java
+++ b/src/bms/model/OSUDecoder.java
@@ -175,7 +175,6 @@ public class OSUDecoder extends ChartDecoder {
 		bgmTl.setBPM(GetBpm(timingPoints, bgmTl.getTime()));
 		bgmTl.setScroll(GetSv(svs, bgmTl.getTime()));
 		bgmTl.setBGA(0);
-		bgmTl.setSectionLine(true);
 
 		for (TimingPoints point : timingPoints) {
 			TimeLine timeline = GetTimeline(timelines, point.time.intValue(), GetSection(timingPoints, point.time.intValue()));
@@ -186,6 +185,23 @@ public class OSUDecoder extends ChartDecoder {
 			TimeLine timeline = GetTimeline(timelines, sv.time.intValue(), GetSection(timingPoints, sv.time.intValue()));
 			timeline.setScroll(100.d / (-sv.beatLength.doubleValue()));
 			timeline.setBPM(GetBpm(timingPoints, sv.time.intValue()));
+		}
+
+		for (int i = 0; i < timingPoints.size(); i++) {
+			int lastNoteTime = osu.hitObjects.get(osu.hitObjects.size() - 1).time;
+			TimingPoints point = timingPoints.get(i);
+			int beginTime = point.time.intValue();
+			int endTime = i < timingPoints.size() - 1 ? timingPoints.get(i + 1).time.intValue() : lastNoteTime;
+			double beginSection = GetSection(timingPoints, beginTime);
+			int duration = endTime - beginTime;
+			float totalSections = duration / (point.beatLength * 4);
+			for (int section = 0; section <= (int)totalSections; section++) {
+				int time = beginTime + (int)(section * point.beatLength * 4);
+				TimeLine line = GetTimeline(timelines, time, beginSection + section);
+				line.setBPM(1 / point.beatLength * 1000 * 60);
+				line.setScroll(GetSv(svs, time));
+				line.setSectionLine(true);
+			}
 		}
 
 		for (int i = 0; i < osu.hitObjects.size(); i++) {

--- a/src/bms/model/osu/Colours.java
+++ b/src/bms/model/osu/Colours.java
@@ -1,0 +1,16 @@
+package bms.model.osu;
+
+import org.w3c.dom.css.RGBColor;
+
+import java.util.Vector;
+
+public class Colours {
+    public static class RGB {
+        public Integer red = 0;
+        public Integer green = 0;
+        public Integer blue = 0;
+    }
+    public Vector<RGB> combo = new Vector<RGB>();
+    public RGB sliderTrackOverride;
+    public RGB sliderBorder;
+}

--- a/src/bms/model/osu/Difficulty.java
+++ b/src/bms/model/osu/Difficulty.java
@@ -1,0 +1,10 @@
+package bms.model.osu;
+
+public class Difficulty {
+    public Float hpDrainRate = 0.f;
+    public Float circleSize = 0.f;
+    public Float overallDifficulty = 0.f;
+    public Float approachRate = 0.f;
+    public Float sliderMultiplier = 0.f;
+    public Float sliderTickRate = 0.f;
+}

--- a/src/bms/model/osu/Editor.java
+++ b/src/bms/model/osu/Editor.java
@@ -1,0 +1,9 @@
+package bms.model.osu;
+
+public class Editor {
+    public Integer[] bookmarks = {};
+    public Float distanceSpacing = 0.f;
+    public Integer beatDivisor = 0;
+    public Integer gridSize = 0;
+    public Float timelineZoom = 0.f;
+}

--- a/src/bms/model/osu/Events.java
+++ b/src/bms/model/osu/Events.java
@@ -1,0 +1,9 @@
+package bms.model.osu;
+
+import java.util.Vector;
+
+public class Events {
+    public String eventType;
+    public Integer startTime;
+    public Vector<String> eventParams = new Vector<String>();
+}

--- a/src/bms/model/osu/General.java
+++ b/src/bms/model/osu/General.java
@@ -1,0 +1,23 @@
+package bms.model.osu;
+
+public class General {
+    public String audioFilename;
+    public Integer audioLeadIn = 0;
+    public String audioHash;
+    public Integer previewTime = -1;
+    public Integer countdown = 1;
+    public String sampleSet = "Normal";
+    public Float stackLeniency = 0.7f;
+    public Integer mode = 0;
+    public Boolean letterboxInBreaks = false;
+    public Boolean storyFireInFront = true;
+    public Boolean useSkinSprites = false;
+    public Boolean alwaysShowPlayfield = false;
+    public String overlayPosition = "NoChange";
+    public String skinPreference;
+    public Boolean epilepsyWarning = false;
+    public Integer countdownOffset = 0;
+    public Boolean specialStyle = false;
+    public Boolean widescreenStoryboard = false;
+    public Boolean samplesMatchPlaybackRate = false;
+}

--- a/src/bms/model/osu/HitObjects.java
+++ b/src/bms/model/osu/HitObjects.java
@@ -1,0 +1,20 @@
+package bms.model.osu;
+
+import java.util.Vector;
+
+public class HitObjects {
+    public static class HitSample {
+        public Integer normalSet = 0;
+        public Integer additionalSet = 0;
+        public Integer index = 0;
+        public Integer volume = 0;
+        public String filename = "";
+    }
+    public Integer x;
+    public Integer y;
+    public Integer time;
+    public Integer type;
+    public Integer hitSound;
+    public Vector<String> objectParams = new Vector<String>();
+    public HitSample hitSample = new HitSample();
+}

--- a/src/bms/model/osu/Metadata.java
+++ b/src/bms/model/osu/Metadata.java
@@ -1,0 +1,14 @@
+package bms.model.osu;
+
+public class Metadata {
+    public String title;
+    public String titleUnicode;
+    public String artist;
+    public String artistUnicode;
+    public String creator;
+    public String version;
+    public String source;
+    public String[] tags;
+    public Integer beatmapId;
+    public Integer beatmapSetId;
+}

--- a/src/bms/model/osu/Osu.java
+++ b/src/bms/model/osu/Osu.java
@@ -1,0 +1,525 @@
+package bms.model.osu;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.Vector;
+
+public class Osu {
+    public Osu(BufferedReader br) {
+        try
+        {
+            String line = null;
+            String section = "";
+            while ((line = br.readLine()) != null) {
+                line = line.split("//")[0];
+                if (line.length() < 2) {
+                    continue;
+                }
+                String lineNoSpace = line.replaceAll("\\s","");
+                if (lineNoSpace.charAt(0) == '[') {
+                    section = lineNoSpace.substring(1, lineNoSpace.length() - 1);
+                    continue;
+                }
+                Integer delimiter = line.indexOf(':');
+
+                String key;
+                String value;
+                if (delimiter > 0) {
+                    if (delimiter > 1 && line.charAt(delimiter - 1) == ' ') {
+                        key = line.substring(0, delimiter - 1);
+                    }
+                    else {
+                        key = line.substring(0, delimiter);
+                    }
+                }
+                else {
+                    key = "";
+                }
+                if (line.length() <= delimiter + 1) {
+                    value = "";
+                }
+                else if (line.charAt(delimiter + 1) == ' ') {
+                    value = line.substring(delimiter + 2);
+                }
+                else {
+                    value = line.substring(delimiter + 1);
+                }
+                switch (section) {
+                    case "General": {
+                        switch(key) {
+                            case "AudioFilename": {
+                                this.general.audioFilename = value;
+                                break;
+                            }
+                            case "AudioLeadIn": {
+                                try {
+                                    this.general.audioLeadIn = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "AudioHash": {
+                                this.general.audioHash = value;
+                                break;
+                            }
+                            case "PreviewTime": {
+                                try {
+                                    this.general.previewTime = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "Countdown": {
+                                try {
+                                    this.general.countdown = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "SampleSet": {
+                                this.general.sampleSet = value;
+                                break;
+                            }
+                            case "StackLeniency": {
+                                try {
+                                    this.general.stackLeniency = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "Mode": {
+                                try {
+                                    this.general.mode = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "LetterboxInBreaks": {
+                                try {
+                                    this.general.letterboxInBreaks = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                            }
+                            case "StoryFireInFront": {
+                                try {
+                                    this.general.storyFireInFront = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "UseSkinSprites": {
+                                try {
+                                    this.general.useSkinSprites = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "AlwaysShowPlayfield": {
+                                try {
+                                    this.general.alwaysShowPlayfield = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "OverlayPosition": {
+                                this.general.overlayPosition = value;
+                                break;
+                            }
+                            case "SkinPreference": {
+                                this.general.skinPreference = value;
+                                break;
+                            }
+                            case "EpilepsyWarning": {
+                                try {
+                                    this.general.epilepsyWarning = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "CountdownOffset": {
+                                try {
+                                    this.general.countdownOffset = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "SpecialStyle": {
+                                try {
+                                    this.general.specialStyle = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "WidescreenStoryboard": {
+                                try {
+                                    this.general.widescreenStoryboard = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "SamplesMatchPlaybackRate": {
+                                try {
+                                    this.general.samplesMatchPlaybackRate = (Integer.parseInt(value) >= 1);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                        }
+                    }
+                    case "Editor": {
+                        switch(key) {
+                            case "Bookmarks": {
+                                String[] values = value.split(",");
+                                this.editor.bookmarks = new Integer[values.length];
+                                for (int i = 0; i < values.length; i++) {
+                                    try {
+                                        this.editor.bookmarks[i] = Integer.parseInt(values[i]);
+                                    }
+                                    catch (NumberFormatException e) {
+                                        continue;
+                                    }
+                                }
+                                break;
+                            }
+                            case "DistanceSpacing": {
+                                try {
+                                    this.editor.distanceSpacing = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "BeatDivisor": {
+                                try {
+                                    this.editor.beatDivisor = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "GridSize": {
+                                try {
+                                    this.editor.gridSize = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "TimelineZoom": {
+                                try {
+                                    this.editor.timelineZoom = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case "Metadata": {
+                        switch(key) {
+                            case "Title": {
+                                this.metadata.title = value;
+                                break;
+                            }
+                            case "TitleUnicode": {
+                                this.metadata.titleUnicode = value;
+                                break;
+                            }
+                            case "Artist": {
+                                this.metadata.artist = value;
+                                break;
+                            }
+                            case "ArtistUnicode": {
+                                this.metadata.artistUnicode = value;
+                                break;
+                            }
+                            case "Creator": {
+                                this.metadata.creator = value;
+                                break;
+                            }
+                            case "Version": {
+                                this.metadata.version = value;
+                                break;
+                            }
+                            case "Source": {
+                                this.metadata.source = value;
+                                break;
+                            }
+                            case "Tags": {
+                                this.metadata.tags = value.split(" ");
+                                break;
+                            }
+                            case "BeatmapID": {
+                                try {
+                                    this.metadata.beatmapId = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "BeatmapSetID": {
+                                try {
+                                    this.metadata.beatmapSetId = Integer.parseInt(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case "Difficulty": {
+                        switch(key) {
+                            case "HPDrainRate": {
+                                try {
+                                    this.difficulty.hpDrainRate = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "CircleSize": {
+                                try {
+                                    this.difficulty.circleSize = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "OverallDifficulty": {
+                                try {
+                                    this.difficulty.overallDifficulty = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "ApproachRate": {
+                                try {
+                                    this.difficulty.approachRate = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "SliderMultiplier": {
+                                try {
+                                    this.difficulty.sliderMultiplier = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                            case "SliderTickRate": {
+                                try {
+                                    this.difficulty.sliderTickRate = Float.parseFloat(value);
+                                }
+                                catch (NumberFormatException e) {
+                                    continue;
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case "Events": {
+                        String[] values = value.split(",");
+                        if (values.length < 3) continue;
+                        Events event = new Events();
+                        event.eventType = values[0];
+                        try {
+                            event.startTime = Integer.parseInt(values[1]);
+                        }
+                        catch(NumberFormatException e) {
+                            event.startTime = 0;
+                        }
+                        for (int i = 2; i < values.length; i++) {
+                            event.eventParams.add(values[i].replace("\"", ""));
+                        }
+                        this.events.add(event);
+                        break;
+                    }
+                    case "TimingPoints": {
+                        String[] values = value.split(",");
+                        if (values.length < 6) continue;
+                        TimingPoints timingPoint = new TimingPoints();
+                        try {
+                            timingPoint.time = Float.parseFloat(values[0]);
+                            timingPoint.beatLength = Float.parseFloat(values[1]);
+                            timingPoint.meter = Integer.parseInt(values[2]);
+                            timingPoint.sampleSet = Integer.parseInt(values[3]);
+                            timingPoint.sampleIndex = Integer.parseInt(values[4]);
+                            timingPoint.volume = Integer.parseInt(values[5]);
+                        }
+                        catch(NumberFormatException e) {
+                            continue;
+                        }
+                        try {
+                            timingPoint.uninherited = (Integer.parseInt(values[6]) >= 1);
+                        }
+                        catch (NumberFormatException e) {
+                            timingPoint.uninherited = true;
+                        }
+                        try {
+                            timingPoint.effects = Integer.parseInt(values[7]);
+                        }
+                        catch (NumberFormatException e) {
+                            timingPoint.effects = 0;
+                        }
+                        this.timingPoints.add(timingPoint);
+                        break;
+                    }
+                    case "Colours": {
+                        String[] values = value.split(",");
+                        if (values.length < 3) continue;
+                        Colours.RGB rgb = new Colours.RGB();
+                        try {
+                            rgb.red = Integer.parseInt(values[0]);
+                            rgb.green = Integer.parseInt(values[1]);
+                            rgb.blue = Integer.parseInt(values[2]);
+                        }
+                        catch(NumberFormatException e) {
+                            continue;
+                        }
+                        switch(key) {
+                            case "SliderTrackOverride": {
+                                this.colours.sliderTrackOverride = rgb;
+                                break;
+                            }
+                            case "SliderBorder": {
+                                this.colours.sliderBorder = rgb;
+                                break;
+                            }
+                            default: {
+                                if (key.startsWith("Combo")) {
+                                    this.colours.combo.add(rgb);
+                                }
+                                break;
+                            }
+                        }
+                        break;
+                    }
+                    case "HitObjects": {
+                        if (!key.isEmpty() && key.charAt(0) != ' ') {
+                            key += ':';
+                            value = key.concat(value);
+                        }
+
+                        String[] values = value.split(",");
+                        if (values.length < 6) continue;
+                        HitObjects hitObject = new HitObjects();
+                        try {
+                            hitObject.x = Integer.parseInt(values[0]);
+                            hitObject.y = Integer.parseInt(values[1]);
+                            hitObject.time = Integer.parseInt(values[2]);
+                            hitObject.type = Integer.parseInt(values[3]);
+                            hitObject.hitSound = Integer.parseInt(values[4]);
+                        }
+                        catch (NumberFormatException e) {
+                            continue;
+                        }
+                        Boolean isManiaHold = (hitObject.type & 0x80) > 0;
+                        if (isManiaHold) {
+                            String[] hitSampleValues = values[values.length -1].split(":");
+                            hitObject.objectParams.add(hitSampleValues[0]);
+                            if (hitSampleValues.length < 5) continue;
+                            try {
+                                hitObject.hitSample.normalSet = Integer.parseInt(hitSampleValues[1]);
+                                hitObject.hitSample.additionalSet = Integer.parseInt(hitSampleValues[2]);
+                                hitObject.hitSample.index = Integer.parseInt(hitSampleValues[3]);
+                                hitObject.hitSample.volume = Integer.parseInt(hitSampleValues[4]);
+                            }
+                            catch (NumberFormatException e) {
+                                continue;
+                            }
+                            if (values[values.length - 1].endsWith(":")) {
+                                hitObject.hitSample.filename = "";
+                            }
+                            else {
+                                hitObject.hitSample.filename = hitSampleValues[5];
+                            }
+                        }
+                        else {
+                            String[] hitSampleValues = values[values.length -1].split(":");
+                            if (hitSampleValues.length < 4) continue;
+                            try {
+                                hitObject.hitSample.normalSet = Integer.parseInt(hitSampleValues[0]);
+                                hitObject.hitSample.additionalSet = Integer.parseInt(hitSampleValues[1]);
+                                hitObject.hitSample.index = Integer.parseInt(hitSampleValues[2]);
+                                hitObject.hitSample.volume = Integer.parseInt(hitSampleValues[3]);
+                            }
+                            catch (NumberFormatException e) {
+                                continue;
+                            }
+                            if (values[values.length - 1].endsWith(":")) {
+                                hitObject.hitSample.filename = "";
+                            }
+                            else {
+                                hitObject.hitSample.filename = hitSampleValues[4];
+                            }
+                        }
+                        this.hitObjects.add(hitObject);
+                        break;
+                    }
+                    default: {
+                        continue;
+                    }
+                }
+            }
+        }
+        catch (IOException e) {
+            return;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return;
+        }
+    }
+    public General general = new General();
+    public Editor editor = new Editor();
+    public Metadata metadata = new Metadata();
+    public Difficulty difficulty = new Difficulty();
+    public Vector<Events> events = new Vector<Events>();
+    public Vector<TimingPoints> timingPoints = new Vector<TimingPoints>();
+    public Colours colours = new Colours();
+    public Vector<HitObjects> hitObjects = new Vector<HitObjects>();
+}

--- a/src/bms/model/osu/TimingPoints.java
+++ b/src/bms/model/osu/TimingPoints.java
@@ -1,0 +1,12 @@
+package bms.model.osu;
+
+public class TimingPoints {
+    public Float time;
+    public Float beatLength;
+    public Integer meter;
+    public Integer sampleSet;
+    public Integer sampleIndex;
+    public Integer volume;
+    public Boolean uninherited = true;
+    public Integer effects = 0;
+}


### PR DESCRIPTION
This adds native support for maps from osu!mania, allowing to add and play them same way as one would do with .bms.

It is a parser part of the project, which includes entirely separate parser and processor for .osu format, with its head being at OSUDecoder.java, and modified format fork at ChartDecoder.java.

It seems to be feature complete and generally working reliably. There might remain edge-case bugs which i couldn't notice without extensive 3rd-party testing. I have been using it personally without issues.

The client part of the project is in a repository for lr2oraja-endlessdream, for which a paired PR can be found at https://github.com/seraxis/lr2oraja-endlessdream/pull/54.